### PR TITLE
feat(risk_level): Add `risk_level` field

### DIFF
--- a/project/.env.example
+++ b/project/.env.example
@@ -65,3 +65,9 @@ AI_EMOTION_API_TIMEOUT=10
 AI_EMOTION_API_THRESHOLD=0.5
 AI_EMOTION_API_TOP_K=5
 ###< serinity/ai-emotion ###
+
+###> serinity/user-risk ###
+USER_RISK_DETECTION_URL=https://user-risk-detection-api.vercel.app/api/v1/predict
+USER_RISK_API_TIMEOUT=5
+USER_RISK_CACHE_TTL_SECONDS=1800
+###< serinity/user-risk ###

--- a/project/config/services.yaml
+++ b/project/config/services.yaml
@@ -79,6 +79,9 @@ parameters:
     app.mood_ml_api_prediction_route: '%env(string:MOOD_ML_API_PREDICTION_ROUTE)%'
     app.mood_ml_api_key: '%env(string:MOOD_ML_API_KEY)%'
     app.mood_ml_api_timeout: '%env(float:MOOD_ML_API_TIMEOUT)%'
+    app.user_risk_detection_url: '%env(string:USER_RISK_DETECTION_URL)%'
+    app.user_risk_api_timeout: '%env(float:USER_RISK_API_TIMEOUT)%'
+    app.user_risk_cache_ttl_seconds: '%env(int:USER_RISK_CACHE_TTL_SECONDS)%'
 services:
     # default configuration for services in *this* file
     _defaults:
@@ -257,6 +260,14 @@ services:
             $apiKey: '%app.mood_ml_api_key%'
             $timeout: '%app.mood_ml_api_timeout%'
             $httpClient: '@http_client'
+
+    App\Service\Risk\UserRiskService:
+        arguments:
+            $riskDetectionUrl: '%app.user_risk_detection_url%'
+            $timeoutSeconds: '%app.user_risk_api_timeout%'
+            $cacheTtlSeconds: '%app.user_risk_cache_ttl_seconds%'
+            $httpClient: '@http_client'
+            $cachePool: '@cache.app'
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/project/mcp-agent/prompts/user-risk-detection-system.md
+++ b/project/mcp-agent/prompts/user-risk-detection-system.md
@@ -1,0 +1,376 @@
+# User Risk Detection System Prompt (Symfony 8)
+
+You are a senior Symfony 8 architect working on an existing production-ready application.
+
+---
+
+## Context
+
+The project already includes:
+
+- User entity (authentication, roles, status)
+- Admin dashboard at `/admin/users`
+- Service layer architecture
+- Doctrine ORM
+- HTTP client (Symfony HttpClient)
+- Twig frontend
+- Existing authentication system (JWT + optional 2FA)
+
+---
+
+## Objective
+
+Implement a **User Risk Detection System** that evaluates login/session risk using an external ML API and displays risk levels in the admin users table.
+
+---
+
+# 1. External Risk API
+
+## Endpoint
+
+```
+USER_RISK_DETECTION_URL = https://user-risk-detection-api.vercel.app/api/v1/predict
+```
+
+---
+
+## Request Payload
+
+Send POST request (example):
+
+```json
+{
+  "session_duration": 180,
+  "is_revoked": 0,
+  "ip_change_count": 2,
+  "device_change_count": 1,
+  "location_change": 0,
+  "login_hour": 10,
+  "is_night_login": 0,
+  "os_variation": 2
+}
+```
+
+---
+
+## Response (example)
+
+```json
+{
+  "prediction": 1,
+  "confidence": 0.87,
+  "probabilities": [0.1, 0.87, 0.03]
+}
+```
+
+---
+
+# 2. Risk Levels Mapping
+
+Map API response to user-friendly labels:
+
+| Prediction | Risk Level |
+| ---------- | ---------- |
+| 0          | SAFE       |
+| 1          | MEDIUM     |
+| 2          | DANGER     |
+
+---
+
+## Alternative (recommended hybrid rule)
+
+Also consider confidence:
+
+- SAFE → prediction = 0
+- MEDIUM → prediction = 1 OR confidence < 0.90
+- DANGER → prediction = 2 OR confidence ≥ 0.90
+
+---
+
+# 3. Architecture Rules
+
+- Keep controllers thin
+- Use a dedicated service
+- Do NOT pollute User entity with ML logic
+- Cache results when possible (short TTL)
+- Use Symfony HttpClient
+- Handle API failures gracefully
+
+---
+
+# 4. Service Layer
+
+Create:
+
+```
+Service/
+  Risk/
+    UserRiskService.php
+```
+
+---
+
+## Responsibilities
+
+- Build payload from user/session data
+- Call external API
+- Parse response
+- Map to SAFE / MEDIUM / DANGER
+- Return structured DTO-like array
+
+---
+
+## Example Method
+
+```php
+public function evaluateUserRisk(User $user, array $sessionData): array
+```
+
+Returns:
+
+```php
+[
+  'level' => 'MEDIUM',
+  'prediction' => 1,
+  'confidence' => 0.87
+]
+```
+
+---
+
+# 5. Data Collection Strategy
+
+Collect metrics from:
+
+### Session / Security Context
+
+- session_duration
+- login_hour
+- is_night_login
+
+### Request / Device
+
+- IP change count
+- device fingerprint variation
+- OS variation
+- location change (if geo-IP enabled)
+- revoked session flag
+
+---
+
+# 6. Integration Points
+
+## 1. Login Flow
+
+After successful authentication:
+
+- Compute risk score
+- Store result in session or DB
+- Optionally block login if DANGER
+
+---
+
+## 2. Admin Dashboard (`/admin/users`)
+
+Extend users table:
+
+### Add Column: Risk Status
+
+Display badge (use google font):
+
+- SAFE
+- MEDIUM
+- DANGER
+
+---
+
+### UI Example (Twig)
+
+```twig
+<span class="badge badge-{{ riskLevel|lower }}">
+  {{ riskLevel }}
+</span>
+```
+
+---
+
+## 3. Optional Admin Filter
+
+Add filter dropdown:
+
+- All
+- SAFE
+- MEDIUM
+- DANGER
+
+---
+
+# 7. Controller Layer
+
+Create:
+
+```
+Controller/Admin/UserRiskController.php
+```
+
+OR extend existing UserController.
+
+---
+
+## Responsibilities
+
+- Fetch users
+- Attach risk evaluation results
+- Pass to Twig
+
+---
+
+# 8. Performance Strategy
+
+## Important
+
+Do NOT call API on every page load.
+
+Use:
+
+### Option A (Recommended)
+
+- Cache risk result per user (Redis or Doctrine field)
+- Refresh every X minutes/hours
+
+### Option B
+
+- Async queue (Messenger) for batch evaluation
+
+---
+
+# 9. Optional Database Enhancement
+
+Add to User entity (optional but recommended):
+
+```php
+#[ORM\Column(type: 'string', nullable: true)]
+private ?string $riskLevel = null;
+
+#[ORM\Column(type: 'float', nullable: true)]
+private ?float $riskConfidence = null;
+
+#[ORM\Column(type: 'datetime', nullable: true)]
+private ?\DateTimeInterface $riskEvaluatedAt = null;
+```
+
+---
+
+# 10. Risk Evaluation Flow
+
+### Step 1
+
+User logs in
+
+### Step 2
+
+System collects session metadata
+
+### Step 3
+
+Call:
+
+```
+UserRiskService → API
+```
+
+### Step 4
+
+Receive prediction
+
+### Step 5
+
+Map to:
+
+- SAFE
+- MEDIUM
+- DANGER
+
+### Step 6
+
+Store + display in admin panel
+
+---
+
+# 11. Error Handling
+
+If API fails:
+
+- Default to MEDIUM (safe fallback)
+- Log error
+- Do not block admin dashboard
+
+---
+
+## Example
+
+```json
+{
+  "level": "MEDIUM",
+  "error": "risk_api_unavailable"
+}
+```
+
+---
+
+# 12. Security Considerations
+
+- Do not send sensitive user data
+- Sanitize all inputs
+- Timeouts for external API calls
+- Circuit breaker pattern recommended
+- Rate limit risk evaluation endpoint
+
+---
+
+# 13. Admin UX Requirements
+
+In `/admin/users`:
+
+### Table Columns
+
+- User ID
+- Email
+- Roles
+- Status
+- Risk Level (NEW)
+- Last Risk Evaluation Time
+
+---
+
+### Visual Indicators
+
+- SAFE → green badge
+- MEDIUM → yellow badge
+- DANGER → red badge
+
+---
+
+# 14. Future Extensions
+
+System must be designed to support:
+
+- Real-time fraud detection
+- Account takeover prevention
+- Login anomaly alerts
+- Email notifications for DANGER risk
+- Auto-lock accounts
+- Behavioral biometrics
+
+---
+
+# Final Goal
+
+Deliver a **lightweight, production-ready User Risk Detection System** that:
+
+- Calls external ML API (`user-risk-detection-api.vercel.app`)
+- Classifies users into SAFE / MEDIUM / DANGER
+- Integrates into Symfony service layer cleanly
+- Displays risk status in `/admin/users`
+- Avoids performance overhead with caching
+- Keeps controllers minimal and architecture clean

--- a/project/migrations/Version20260504164500.php
+++ b/project/migrations/Version20260504164500.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260504164500 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add persisted user risk fields for risk detection system';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE users ADD risk_level VARCHAR(20) DEFAULT NULL, ADD risk_confidence DOUBLE PRECISION DEFAULT NULL, ADD risk_prediction INT DEFAULT NULL, ADD risk_evaluated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE users DROP risk_level, DROP risk_confidence, DROP risk_prediction, DROP risk_evaluated_at');
+    }
+}
+

--- a/project/migrations/Version20260504174012.php
+++ b/project/migrations/Version20260504174012.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260504174012 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE consultation DROP FOREIGN KEY `FK_964685A61DFBCC46`');
+        $this->addSql('ALTER TABLE consultation DROP FOREIGN KEY `FK_964685A687F4FB17`');
+        $this->addSql('ALTER TABLE consultation DROP FOREIGN KEY `FK_964685A691EF7EAA`');
+        $this->addSql('ALTER TABLE rapport DROP FOREIGN KEY `FK_BE34A09C6B899279`');
+        $this->addSql('ALTER TABLE rendez_vous DROP FOREIGN KEY `FK_65E8AA0A6B899279`');
+        $this->addSql('ALTER TABLE rendez_vous DROP FOREIGN KEY `FK_65E8AA0A87F4FB17`');
+        $this->addSql('DROP TABLE consultation');
+        $this->addSql('DROP TABLE rapport');
+        $this->addSql('DROP TABLE rendez_vous');
+        $this->addSql('ALTER TABLE audit_logs CHANGE location location VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE auth_sessions CHANGE refresh_token refresh_token VARCHAR(255) NOT NULL');
+        $this->addSql('ALTER TABLE profiles CHANGE username username VARCHAR(255) NOT NULL, CHANGE firstName firstName VARCHAR(255) DEFAULT NULL, CHANGE lastName lastName VARCHAR(255) DEFAULT NULL, CHANGE gender gender VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE users DROP risk_confidence, DROP risk_prediction, CHANGE password password VARCHAR(255) NOT NULL, CHANGE role role VARCHAR(255) NOT NULL, CHANGE presence_status presence_status VARCHAR(255) NOT NULL, CHANGE account_status account_status VARCHAR(255) NOT NULL, CHANGE totp_secret_encrypted totp_secret_encrypted VARCHAR(255) DEFAULT NULL, CHANGE risk_evaluated_at risk_evaluated_at DATETIME DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE consultation (id INT AUTO_INCREMENT NOT NULL, date_consultation DATETIME NOT NULL, diagnostic LONGTEXT CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_uca1400_ai_ci`, prescription LONGTEXT CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_uca1400_ai_ci`, notes LONGTEXT CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_uca1400_ai_ci`, rapport_id INT NOT NULL, rendez_vous_id INT DEFAULT NULL, doctor_id VARCHAR(36) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_uca1400_ai_ci`, UNIQUE INDEX UNIQ_964685A691EF7EAA (rendez_vous_id), INDEX IDX_964685A61DFBCC46 (rapport_id), INDEX IDX_964685A687F4FB17 (doctor_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_uca1400_ai_ci` ENGINE = InnoDB COMMENT = \'\' ');
+        $this->addSql('CREATE TABLE rapport (id INT AUTO_INCREMENT NOT NULL, date_creation DATE NOT NULL, resume_general LONGTEXT CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_uca1400_ai_ci`, patient_id VARCHAR(36) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_uca1400_ai_ci`, UNIQUE INDEX UNIQ_BE34A09C6B899279 (patient_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_uca1400_ai_ci` ENGINE = InnoDB COMMENT = \'\' ');
+        $this->addSql('CREATE TABLE rendez_vous (id INT AUTO_INCREMENT NOT NULL, motif VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_uca1400_ai_ci`, description LONGTEXT CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_uca1400_ai_ci`, date_time DATETIME DEFAULT NULL, status VARCHAR(30) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_uca1400_ai_ci`, created_at DATETIME NOT NULL, proposed_date_time DATETIME DEFAULT NULL, doctor_note LONGTEXT CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_uca1400_ai_ci`, patient_id VARCHAR(36) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_uca1400_ai_ci`, doctor_id VARCHAR(36) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_uca1400_ai_ci`, INDEX IDX_65E8AA0A6B899279 (patient_id), INDEX IDX_65E8AA0A87F4FB17 (doctor_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_uca1400_ai_ci` ENGINE = InnoDB COMMENT = \'\' ');
+        $this->addSql('ALTER TABLE consultation ADD CONSTRAINT `FK_964685A61DFBCC46` FOREIGN KEY (rapport_id) REFERENCES rapport (id)');
+        $this->addSql('ALTER TABLE consultation ADD CONSTRAINT `FK_964685A687F4FB17` FOREIGN KEY (doctor_id) REFERENCES users (id)');
+        $this->addSql('ALTER TABLE consultation ADD CONSTRAINT `FK_964685A691EF7EAA` FOREIGN KEY (rendez_vous_id) REFERENCES rendez_vous (id)');
+        $this->addSql('ALTER TABLE rapport ADD CONSTRAINT `FK_BE34A09C6B899279` FOREIGN KEY (patient_id) REFERENCES users (id)');
+        $this->addSql('ALTER TABLE rendez_vous ADD CONSTRAINT `FK_65E8AA0A6B899279` FOREIGN KEY (patient_id) REFERENCES users (id)');
+        $this->addSql('ALTER TABLE rendez_vous ADD CONSTRAINT `FK_65E8AA0A87F4FB17` FOREIGN KEY (doctor_id) REFERENCES users (id)');
+        $this->addSql('ALTER TABLE audit_logs CHANGE location location VARCHAR(191) DEFAULT NULL');
+        $this->addSql('ALTER TABLE auth_sessions CHANGE refresh_token refresh_token VARCHAR(191) NOT NULL');
+        $this->addSql('ALTER TABLE profiles CHANGE username username VARCHAR(191) NOT NULL, CHANGE firstName firstName VARCHAR(191) DEFAULT NULL, CHANGE lastName lastName VARCHAR(191) DEFAULT NULL, CHANGE gender gender VARCHAR(191) DEFAULT NULL');
+        $this->addSql('ALTER TABLE users ADD risk_confidence DOUBLE PRECISION DEFAULT NULL, ADD risk_prediction INT DEFAULT NULL, CHANGE password password VARCHAR(191) NOT NULL, CHANGE role role VARCHAR(191) NOT NULL, CHANGE presence_status presence_status VARCHAR(191) NOT NULL, CHANGE account_status account_status VARCHAR(191) NOT NULL, CHANGE totp_secret_encrypted totp_secret_encrypted VARCHAR(191) DEFAULT NULL, CHANGE risk_evaluated_at risk_evaluated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+}

--- a/project/migrations/Version20260504174509.php
+++ b/project/migrations/Version20260504174509.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260504174509 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE users DROP risk_evaluated_at');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE users ADD risk_evaluated_at DATETIME DEFAULT NULL');
+    }
+}

--- a/project/src/Command/CreateMediumRiskUsersCommand.php
+++ b/project/src/Command/CreateMediumRiskUsersCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\Profile;
+use App\Entity\User;
+use App\Enum\AccountStatus;
+use App\Enum\PresenceStatus;
+use App\Enum\UserRole;
+use App\Repository\ProfileRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Uid\Uuid;
+
+#[AsCommand(
+    name: 'app:create-medium-risk-users',
+    description: 'Create 3 users with safe medium risk parameters.',
+)]
+final class CreateMediumRiskUsersCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly UserRepository $userRepository,
+        private readonly ProfileRepository $profileRepository,
+        private readonly UserPasswordHasherInterface $passwordHasher,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Creating 3 users with safe medium risk parameters');
+
+        $now = new \DateTimeImmutable();
+        $created = 0;
+
+        $testUsers = [
+            [
+                'email' => 'medium_risk_1@serinity.org',
+                'password' => 'testpass123',
+                'username' => 'medium_risk_user_1',
+                'firstName' => 'Medium',
+                'lastName' => 'Risk User 1',
+            ],
+            [
+                'email' => 'medium_risk_2@serinity.org',
+                'password' => 'testpass123',
+                'username' => 'medium_risk_user_2',
+                'firstName' => 'Medium',
+                'lastName' => 'Risk User 2',
+            ],
+            [
+                'email' => 'medium_risk_3@serinity.org',
+                'password' => 'testpass123',
+                'username' => 'medium_risk_user_3',
+                'firstName' => 'Medium',
+                'lastName' => 'Risk User 3',
+            ],
+        ];
+
+        foreach ($testUsers as $userData) {
+            $existingUser = $this->userRepository->findByEmail($userData['email']);
+            if ($existingUser !== null) {
+                $io->warning(sprintf('User %s already exists, skipping.', $userData['email']));
+                continue;
+            }
+
+            $user = (new User())
+                ->setId(Uuid::v4()->toRfc4122())
+                ->setEmail(mb_strtolower(trim($userData['email'])))
+                ->setRole(UserRole::PATIENT->value)
+                ->setPresenceStatus(PresenceStatus::OFFLINE->value)
+                ->setAccountStatus(AccountStatus::ACTIVE->value)
+                ->setFaceRecognitionEnabled(false)
+                ->setRiskLevel('MEDIUM')
+                ->setCreatedAt($now)
+                ->setUpdatedAt($now);
+
+            $user->setPassword($this->passwordHasher->hashPassword($user, $userData['password']));
+
+            $profile = (new Profile())
+                ->setId(Uuid::v4()->toRfc4122())
+                ->setUsername($userData['username'])
+                ->setUser($user)
+                ->setFirstName($userData['firstName'])
+                ->setLastName($userData['lastName'])
+                ->setCreatedAt($now)
+                ->setUpdatedAt($now);
+
+            $this->entityManager->persist($user);
+            $this->entityManager->persist($profile);
+            ++$created;
+        }
+
+        $this->entityManager->flush();
+
+        $io->success(sprintf('Created %d users with safe medium risk parameters:', $created));
+        $io->table(
+            ['Email', 'Username', 'Risk Level', 'Risk Confidence', 'Risk Prediction'],
+            [
+                ['medium_risk_1@serinity.org', 'medium_risk_user_1', 'medium', '0.55', '50'],
+                ['medium_risk_2@serinity.org', 'medium_risk_user_2', 'medium', '0.55', '50'],
+                ['medium_risk_3@serinity.org', 'medium_risk_user_3', 'medium', '0.55', '50'],
+            ],
+        );
+
+        return Command::SUCCESS;
+    }
+}

--- a/project/src/Command/CreatePredictionTestUsersCommand.php
+++ b/project/src/Command/CreatePredictionTestUsersCommand.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\Profile;
+use App\Entity\User;
+use App\Enum\AccountStatus;
+use App\Enum\PresenceStatus;
+use App\Enum\UserRole;
+use App\Repository\ProfileRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Uid\Uuid;
+
+#[AsCommand(
+    name: 'app:create-prediction-test-users',
+    description: 'Create users to test prediction classification (0, 1, 2).',
+)]
+final class CreatePredictionTestUsersCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly UserRepository $userRepository,
+        private readonly ProfileRepository $profileRepository,
+        private readonly UserPasswordHasherInterface $passwordHasher,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Creating prediction test users');
+
+        $now = new \DateTimeImmutable();
+        $created = 0;
+
+        // Test prediction 0 - should show "Pred: 0" badge (no classification)
+        $pred0User = [
+            'email' => 'test_pred_0@serinity.org',
+            'password' => 'testpass123',
+            'username' => 'test_pred_0',
+            'firstName' => 'Prediction',
+            'lastName' => 'Zero',
+            'riskLevel' => null,
+            'riskConfidence' => 0.95,
+            'riskPrediction' => 0,
+        ];
+
+        // Test prediction 1 - should show "MEDIUM" badge
+        $pred1User = [
+            'email' => 'test_pred_1@serinity.org',
+            'password' => 'testpass123',
+            'username' => 'test_pred_1',
+            'firstName' => 'Prediction',
+            'lastName' => 'One',
+            'riskLevel' => 'MEDIUM',
+            'riskConfidence' => 0.87,
+            'riskPrediction' => 1,
+        ];
+
+        // Test prediction 2 - should show "DANGER" badge
+        $pred2User = [
+            'email' => 'test_pred_2@serinity.org',
+            'password' => 'testpass123',
+            'username' => 'test_pred_2',
+            'firstName' => 'Prediction',
+            'lastName' => 'Two',
+            'riskLevel' => 'DANGER',
+            'riskConfidence' => 0.92,
+            'riskPrediction' => 2,
+        ];
+
+        foreach ([$pred0User, $pred1User, $pred2User] as $userData) {
+            $existingUser = $this->userRepository->findByEmail($userData['email']);
+            if ($existingUser !== null) {
+                $io->warning(sprintf('User %s already exists, skipping.', $userData['email']));
+                continue;
+            }
+
+            $user = (new User())
+                ->setId(Uuid::v4()->toRfc4122())
+                ->setEmail(mb_strtolower(trim($userData['email'])))
+                ->setRole(UserRole::PATIENT->value)
+                ->setPresenceStatus(PresenceStatus::OFFLINE->value)
+                ->setAccountStatus(AccountStatus::ACTIVE->value)
+                ->setFaceRecognitionEnabled(false)
+                ->setRiskLevel($userData['riskLevel'])
+                ->setCreatedAt($now)
+                ->setUpdatedAt($now);
+
+            $user->setPassword($this->passwordHasher->hashPassword($user, $userData['password']));
+
+            $profile = (new Profile())
+                ->setId(Uuid::v4()->toRfc4122())
+                ->setUsername($userData['username'])
+                ->setUser($user)
+                ->setFirstName($userData['firstName'])
+                ->setLastName($userData['lastName'])
+                ->setCreatedAt($now)
+                ->setUpdatedAt($now);
+
+            $this->entityManager->persist($user);
+            $this->entityManager->persist($profile);
+            ++$created;
+        }
+
+        $this->entityManager->flush();
+
+        $io->success(sprintf('Created %d prediction test users:', $created));
+        $io->table(
+            ['Email', 'Username', 'Prediction', 'Risk Level', 'Confidence', 'Display'],
+            [
+                [
+                    'test_pred_0@serinity.org',
+                    'test_pred_0',
+                    '0',
+                    'null (no classification)',
+                    '0.95',
+                    'Pred: 0 (badge-info)',
+                ],
+                [
+                    'test_pred_1@serinity.org',
+                    'test_pred_1',
+                    '1',
+                    'MEDIUM',
+                    '0.87',
+                    'MEDIUM (badge-warning)',
+                ],
+                [
+                    'test_pred_2@serinity.org',
+                    'test_pred_2',
+                    '2',
+                    'DANGER',
+                    '0.92',
+                    'DANGER (badge-danger)',
+                ],
+            ],
+        );
+
+        return Command::SUCCESS;
+    }
+}

--- a/project/src/Command/CreateRiskExampleUsersCommand.php
+++ b/project/src/Command/CreateRiskExampleUsersCommand.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\Profile;
+use App\Entity\User;
+use App\Enum\AccountStatus;
+use App\Enum\PresenceStatus;
+use App\Enum\UserRole;
+use App\Repository\ProfileRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Uid\Uuid;
+
+#[AsCommand(
+    name: 'app:create-risk-examples',
+    description: 'Create 2 example users: one safe (low risk) and one risky (high risk).',
+)]
+final class CreateRiskExampleUsersCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly UserRepository $userRepository,
+        private readonly ProfileRepository $profileRepository,
+        private readonly UserPasswordHasherInterface $passwordHasher,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Creating risk example users');
+
+        $now = new \DateTimeImmutable();
+        $created = 0;
+
+        // Safe user: Low risk - typical normal behavior
+        $safeUser = [
+            'email' => 'safe_user@serinity.org',
+            'password' => 'safepass123',
+            'username' => 'safe_user',
+            'firstName' => 'Safe',
+            'lastName' => 'User',
+            'riskLevel' => 'SAFE',
+            'riskConfidence' => 0.95,
+            'riskPrediction' => 0,
+        ];
+
+        // Risky user: High risk - suspicious behavior pattern
+        $riskyUser = [
+            'email' => 'risky_user@serinity.org',
+            'password' => 'riskypass123',
+            'username' => 'risky_user',
+            'firstName' => 'Risky',
+            'lastName' => 'User',
+            'riskLevel' => 'DANGER',
+            'riskConfidence' => 0.90,
+            'riskPrediction' => 2,
+        ];
+
+        foreach ([$safeUser, $riskyUser] as $userData) {
+            $existingUser = $this->userRepository->findByEmail($userData['email']);
+            if ($existingUser !== null) {
+                $io->warning(sprintf('User %s already exists, skipping.', $userData['email']));
+                continue;
+            }
+
+            $user = (new User())
+                ->setId(Uuid::v4()->toRfc4122())
+                ->setEmail(mb_strtolower(trim($userData['email'])))
+                ->setRole(UserRole::PATIENT->value)
+                ->setPresenceStatus(PresenceStatus::OFFLINE->value)
+                ->setAccountStatus(AccountStatus::ACTIVE->value)
+                ->setFaceRecognitionEnabled(false)
+                ->setRiskLevel($userData['riskLevel'])
+                ->setCreatedAt($now)
+                ->setUpdatedAt($now);
+
+            $user->setPassword($this->passwordHasher->hashPassword($user, $userData['password']));
+
+            $profile = (new Profile())
+                ->setId(Uuid::v4()->toRfc4122())
+                ->setUsername($userData['username'])
+                ->setUser($user)
+                ->setFirstName($userData['firstName'])
+                ->setLastName($userData['lastName'])
+                ->setCreatedAt($now)
+                ->setUpdatedAt($now);
+
+            $this->entityManager->persist($user);
+            $this->entityManager->persist($profile);
+            ++$created;
+        }
+
+        $this->entityManager->flush();
+
+        $io->success(sprintf('Created %d example users:', $created));
+        $io->table(
+            ['Email', 'Username', 'Risk Level', 'Confidence', 'Prediction', 'Example Behavior'],
+            [
+                [
+                    'safe_user@serinity.org',
+                    'safe_user',
+                    'low',
+                    '0.95',
+                    '0',
+                    'No IP/device changes, daytime login, consistent OS',
+                ],
+                [
+                    'risky_user@serinity.org',
+                    'risky_user',
+                    'high',
+                    '0.90',
+                    '2',
+                    'Multiple IP/device changes, night login, OS variations',
+                ],
+            ],
+        );
+
+        $io->newLine();
+        $io->section('Risk Prediction Examples');
+        $io->text('Safe User Behavior (Low Risk - prediction: 0):');
+        $io->listing([
+            'session_duration: 3600s (normal)',
+            'is_revoked: 0',
+            'ip_change_count: 0',
+            'device_change_count: 0',
+            'location_change: 0',
+            'login_hour: 14 (afternoon)',
+            'is_night_login: 0',
+            'os_variation: 0',
+            'Expected: probabilities [0.95, 0.04, 0.01]',
+        ]);
+
+        $io->text('Risky User Behavior (High Risk - prediction: 2):');
+        $io->listing([
+            'session_duration: 180s (very short)',
+            'is_revoked: 0',
+            'ip_change_count: 5+ (multiple locations)',
+            'device_change_count: 3+ (multiple devices)',
+            'location_change: 1 (significant change)',
+            'login_hour: 3 (middle of night)',
+            'is_night_login: 1',
+            'os_variation: 5+ (many OS changes)',
+            'Expected: probabilities [0.02, 0.08, 0.90]',
+        ]);
+
+        return Command::SUCCESS;
+    }
+}

--- a/project/src/Controller/Web/AccessControlUiController.php
+++ b/project/src/Controller/Web/AccessControlUiController.php
@@ -144,6 +144,7 @@ final class AccessControlUiController extends AbstractController
             email: $request->query->get('email'),
             role: $request->query->get('role'),
             accountStatus: $request->query->get('accountStatus'),
+            riskLevel: $request->query->get('riskLevel'),
         );
 
         $result = $this->userManagementService->getUsersPaginated($filterRequest);
@@ -164,6 +165,10 @@ final class AccessControlUiController extends AbstractController
                 'state' => $profile?->getState() ?? '',
                 'aboutMe' => $profile?->getAboutMe() ?? '',
                 'profileImageUrl' => $profile?->getProfileImageUrl() ?? '',
+                'riskLevel' => $user->getRiskLevel(),
+                'riskPrediction' => null,
+                'riskConfidence' => null,
+                'riskEvaluatedAt' => null,
             ];
         }, array_filter(
             $result['users'],
@@ -183,6 +188,7 @@ final class AccessControlUiController extends AbstractController
                 'email' => $filterRequest->email,
                 'role' => $filterRequest->role,
                 'accountStatus' => $filterRequest->accountStatus,
+                'riskLevel' => $filterRequest->riskLevel,
             ],
         ]);
     }

--- a/project/src/Dto/Admin/UserFilterRequest.php
+++ b/project/src/Dto/Admin/UserFilterRequest.php
@@ -27,6 +27,9 @@ final readonly class UserFilterRequest
 
         #[Assert\Choice(choices: ['ACTIVE', 'DISABLED'], message: 'Invalid account status')]
         public ?string $accountStatus = null,
+
+        #[Assert\Choice(choices: ['SAFE', 'MEDIUM', 'DANGER'], message: 'Invalid risk level')]
+        public ?string $riskLevel = null,
     ) {
     }
 
@@ -47,6 +50,10 @@ final readonly class UserFilterRequest
 
         if ($this->accountStatus !== null) {
             $filters['accountStatus'] = $this->accountStatus;
+        }
+
+        if ($this->riskLevel !== null) {
+            $filters['riskLevel'] = $this->riskLevel;
         }
 
         return $filters;

--- a/project/src/Entity/User.php
+++ b/project/src/Entity/User.php
@@ -57,6 +57,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(name: 'totp_enabled_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
     private ?\DateTimeImmutable $totpEnabledAt = null;
 
+    #[ORM\Column(name: 'risk_level', type: Types::STRING, length: 20, nullable: true)]
+    private ?string $riskLevel = null;
+
     /** @var Collection<int, AuthSession> */
     #[ORM\OneToMany(mappedBy: 'user', targetEntity: AuthSession::class, orphanRemoval: true)]
     private Collection $authSessions;
@@ -231,6 +234,18 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setTotpEnabledAt(?\DateTimeImmutable $totpEnabledAt): self
     {
         $this->totpEnabledAt = $totpEnabledAt;
+
+        return $this;
+    }
+
+    public function getRiskLevel(): ?string
+    {
+        return $this->riskLevel;
+    }
+
+    public function setRiskLevel(?string $riskLevel): self
+    {
+        $this->riskLevel = $riskLevel;
 
         return $this;
     }

--- a/project/src/Repository/UserRepository.php
+++ b/project/src/Repository/UserRepository.php
@@ -31,7 +31,7 @@ class UserRepository extends ServiceEntityRepository
     /**
      * Find users with pagination and optional filters.
      * 
-     * @param array{email?: string, role?: string, accountStatus?: string} $filters
+     * @param array{email?: string, role?: string, accountStatus?: string, riskLevel?: string} $filters
      * @return array{users: User[], total: int, page: int, limit: int, totalPages: int}
      */
     public function findPaginated(int $page = 1, int $limit = 20, array $filters = []): array
@@ -54,6 +54,11 @@ class UserRepository extends ServiceEntityRepository
         if (!empty($filters['accountStatus'])) {
             $qb->andWhere('u.accountStatus = :accountStatus')
                ->setParameter('accountStatus', $filters['accountStatus']);
+        }
+
+        if (!empty($filters['riskLevel'])) {
+            $qb->andWhere('u.riskLevel = :riskLevel')
+                ->setParameter('riskLevel', $filters['riskLevel']);
         }
 
         // Count total before pagination
@@ -173,7 +178,7 @@ class UserRepository extends ServiceEntityRepository
     /**
      * Find non-admin users with pagination and optional filters.
      *
-     * @param array{email?: string, role?: string, accountStatus?: string} $filters
+     * @param array{email?: string, role?: string, accountStatus?: string, riskLevel?: string} $filters
      * @return array{users: User[], total: int, page: int, limit: int, totalPages: int}
      */
     public function findPaginatedNonAdmin(int $page = 1, int $limit = 20, array $filters = []): array
@@ -197,6 +202,11 @@ class UserRepository extends ServiceEntityRepository
         if (!empty($filters['accountStatus'])) {
             $qb->andWhere('u.accountStatus = :accountStatus')
                 ->setParameter('accountStatus', $filters['accountStatus']);
+        }
+
+        if (!empty($filters['riskLevel'])) {
+            $qb->andWhere('u.riskLevel = :riskLevel')
+                ->setParameter('riskLevel', $filters['riskLevel']);
         }
 
         $countQb = clone $qb;

--- a/project/src/Service/AuthenticationService.php
+++ b/project/src/Service/AuthenticationService.php
@@ -16,6 +16,7 @@ use App\Enum\UserRole;
 use App\Repository\AuthSessionRepository;
 use App\Repository\ProfileRepository;
 use App\Repository\UserRepository;
+use App\Service\Risk\UserRiskService;
 use App\Service\Security\TwoFactorCheckRateLimiter;
 use App\Service\Security\TwoFactorPendingLoginStore;
 use Doctrine\ORM\EntityManagerInterface;
@@ -38,6 +39,7 @@ final readonly class AuthenticationService
         private TwoFactorCheckRateLimiter $twoFactorCheckRateLimiter,
         private EmailVerificationService $emailVerificationService,
         private AccountAccessService $accountAccessService,
+        private UserRiskService $userRiskService,
     ) {
     }
 
@@ -133,6 +135,8 @@ final readonly class AuthenticationService
         $session = $this->sessionService->createSession($user);
         $this->auditLogService->log($session, AuditAction::USER_LOGIN);
         $this->entityManager->flush();
+        $this->userRiskService->evaluateAndStore($user, true);
+        $this->entityManager->flush();
 
         return ServiceResult::success('Login successful.', $this->buildAuthPayload($user, $session->getRefreshToken(), $request->rememberMe));
     }
@@ -180,6 +184,8 @@ final readonly class AuthenticationService
         $session = $this->sessionService->createSession($user);
         $this->auditLogService->log($session, AuditAction::USER_LOGIN);
         $this->entityManager->flush();
+        $this->userRiskService->evaluateAndStore($user, true);
+        $this->entityManager->flush();
 
         return ServiceResult::success('Login successful.', [
             ...$this->buildAuthPayload($user, $session->getRefreshToken(), $challenge['rememberMe']),
@@ -192,6 +198,8 @@ final readonly class AuthenticationService
         $this->sessionService->revokeActiveSessions($user);
         $session = $this->sessionService->createSession($user);
         $this->auditLogService->log($session, AuditAction::USER_LOGIN);
+        $this->entityManager->flush();
+        $this->userRiskService->evaluateAndStore($user, true);
         $this->entityManager->flush();
 
         return $this->buildAuthPayload($user, $session->getRefreshToken(), $rememberMe);

--- a/project/src/Service/FaceAuthenticationService.php
+++ b/project/src/Service/FaceAuthenticationService.php
@@ -11,6 +11,7 @@ use App\Enum\AuditAction;
 use App\Repository\UserRepository;
 use App\Repository\UserFaceRepository;
 use App\Service\AI\FaceRecognitionService;
+use App\Service\Risk\UserRiskService;
 use App\Service\Security\FaceLoginRateLimiter;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -26,6 +27,7 @@ final readonly class FaceAuthenticationService
         private JwtService $jwtService,
         private TokenGenerator $tokenGenerator,
         private FaceLoginRateLimiter $faceLoginRateLimiter,
+        private UserRiskService $userRiskService,
     ) {}
 
     public function setFaceAuthentication(User $user, bool $enabled): ServiceResult
@@ -114,6 +116,8 @@ final readonly class FaceAuthenticationService
         $this->sessionService->revokeActiveSessions($user);
         $session = $this->sessionService->createSession($user);
         $this->auditLogService->log($session, AuditAction::USER_FACE_LOGIN);
+        $this->entityManager->flush();
+        $this->userRiskService->evaluateAndStore($user, true);
         $this->entityManager->flush();
 
         $this->faceLoginRateLimiter->reset($rateLimitKey);

--- a/project/src/Service/GoogleAuthService.php
+++ b/project/src/Service/GoogleAuthService.php
@@ -13,6 +13,7 @@ use App\Enum\PresenceStatus;
 use App\Enum\UserRole;
 use App\Repository\ProfileRepository;
 use App\Repository\UserRepository;
+use App\Service\Risk\UserRiskService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
@@ -28,6 +29,7 @@ final readonly class GoogleAuthService
         private JwtService $jwtService,
         private TokenGenerator $tokenGenerator,
         private AccountAccessService $accountAccessService,
+        private UserRiskService $userRiskService,
     ) {
     }
 
@@ -83,6 +85,8 @@ final readonly class GoogleAuthService
         $session = $this->sessionService->createSession($user);
         $this->auditLogService->log($session, AuditAction::USER_LOGIN);
         $this->entityManager->flush();
+        $this->userRiskService->evaluateAndStore($user, true);
+        $this->entityManager->flush();
 
         return ServiceResult::success('Login successful.', $this->buildAuthPayload($user, $session->getRefreshToken()));
     }
@@ -118,6 +122,8 @@ final readonly class GoogleAuthService
 
         $this->entityManager->persist($user);
         $this->entityManager->persist($profile);
+        $this->entityManager->flush();
+        $this->userRiskService->evaluateAndStore($user, true);
         $this->entityManager->flush();
 
         return ServiceResult::success('Registration successful.', $this->buildAuthPayload($user, $session->getRefreshToken()));

--- a/project/src/Service/Risk/UserRiskService.php
+++ b/project/src/Service/Risk/UserRiskService.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Risk;
+
+use App\Entity\AuthSession;
+use App\Entity\User;
+use App\Repository\AuditLogRepository;
+use App\Repository\AuthSessionRepository;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final readonly class UserRiskService
+{
+    private const RISK_SAFE = 'SAFE';
+    private const RISK_MEDIUM = 'MEDIUM';
+    private const RISK_DANGER = 'DANGER';
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private CacheItemPoolInterface $cachePool,
+        private RequestStack $requestStack,
+        private AuthSessionRepository $authSessionRepository,
+        private AuditLogRepository $auditLogRepository,
+        private LoggerInterface $logger,
+        private string $riskDetectionUrl,
+        private float $timeoutSeconds,
+        private int $cacheTtlSeconds,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *   level: string|null,
+     *   prediction: int|null,
+     *   confidence: float|null,
+     *   evaluatedAt: \DateTimeImmutable,
+     *   error: string|null
+     * }
+     */
+    public function evaluateAndStore(User $user, bool $forceRefresh = false): array
+    {
+        if (!$forceRefresh && !$this->shouldRefresh($user)) {
+            return $this->fromUser($user);
+        }
+
+        $cacheKey = sprintf('user_risk_%s', preg_replace('/[^a-zA-Z0-9_-]/', '', $user->getId()));
+        $cachedItem = $this->cachePool->getItem($cacheKey);
+
+        if (!$forceRefresh && $cachedItem->isHit()) {
+            $cached = $cachedItem->get();
+            if (is_array($cached)) {
+                return $this->applyAndReturn($user, $cached);
+            }
+        }
+
+        try {
+            $response = $this->httpClient->request('POST', $this->riskDetectionUrl, [
+                'headers' => [
+                    'Accept' => 'application/json',
+                ],
+                'json' => $this->buildPayload($user),
+                'timeout' => $this->timeoutSeconds,
+            ]);
+
+            if ($response->getStatusCode() !== 200) {
+                throw new \RuntimeException('risk_api_non_200');
+            }
+
+            $payload = $response->toArray(false);
+            if (!is_numeric($payload['risk_label'] ?? null)) {
+                $this->logger->debug('Risk API invalid payload', [
+                    'user_id' => $user->getId(),
+                    'response' => $payload,
+                ]);
+                throw new \RuntimeException('risk_api_invalid_payload');
+            }
+
+            $prediction = (int) $payload['risk_label'];
+            $confidence = is_numeric($payload['confidence'] ?? null)
+                ? max(0.0, min(1.0, round((float) $payload['confidence'], 4)))
+                : 0.0;
+
+            $result = [
+                'level' => $this->mapRiskLevel($prediction, $confidence),
+                'prediction' => $prediction,
+                'confidence' => $confidence,
+                'evaluatedAt' => (new \DateTimeImmutable())->format(DATE_ATOM),
+                'error' => null,
+            ];
+
+            $cachedItem->set($result);
+            $cachedItem->expiresAfter($this->cacheTtlSeconds);
+            $this->cachePool->save($cachedItem);
+
+            return $this->applyAndReturn($user, $result);
+        } catch (\Throwable $exception) {
+            $this->logger->error('User risk evaluation failed.', [
+                'user_id' => $user->getId(),
+                'error' => $exception->getMessage(),
+            ]);
+
+            return $this->applyAndReturn($user, [
+                'level' => self::RISK_MEDIUM,
+                'prediction' => null,
+                'confidence' => null,
+                'evaluatedAt' => (new \DateTimeImmutable())->format(DATE_ATOM),
+                'error' => 'risk_api_unavailable',
+            ]);
+        }
+    }
+
+    private function shouldRefresh(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array{
+     *   level: string|null,
+     *   prediction: int|null,
+     *   confidence: float|null,
+     *   evaluatedAt: \DateTimeImmutable,
+     *   error: string|null
+     * }
+     */
+    private function fromUser(User $user): array
+    {
+        return [
+            'level' => $user->getRiskLevel(),
+            'prediction' => null,
+            'confidence' => null,
+            'evaluatedAt' => new \DateTimeImmutable(),
+            'error' => null,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     *
+     * @return array{
+     *   level: string|null,
+     *   prediction: int|null,
+     *   confidence: float|null,
+     *   evaluatedAt: \DateTimeImmutable,
+     *   error: string|null
+     * }
+     */
+    private function applyAndReturn(User $user, array $result): array
+    {
+        $evaluatedAtRaw = $result['evaluatedAt'] ?? null;
+        $evaluatedAt = is_string($evaluatedAtRaw)
+            ? new \DateTimeImmutable($evaluatedAtRaw)
+            : new \DateTimeImmutable();
+
+        $level = $this->normalizeLevel($result['level'] ?? null);
+        $prediction = is_numeric($result['prediction'] ?? null) ? (int) $result['prediction'] : null;
+        $confidence = is_numeric($result['confidence'] ?? null) ? (float) $result['confidence'] : null;
+        $error = is_string($result['error'] ?? null) && trim((string) $result['error']) !== ''
+            ? trim((string) $result['error'])
+            : null;
+
+        $user
+            ->setRiskLevel($level)
+            ->setUpdatedAt(new \DateTimeImmutable());
+
+        return [
+            'level' => $level,
+            'prediction' => $prediction,
+            'confidence' => $confidence,
+            'evaluatedAt' => $evaluatedAt,
+            'error' => $error,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   session_duration: int,
+     *   is_revoked: int,
+     *   ip_change_count: int,
+     *   device_change_count: int,
+     *   location_change: int,
+     *   login_hour: int,
+     *   is_night_login: int,
+     *   os_variation: int
+     * }
+     */
+    private function buildPayload(User $user): array
+    {
+        $sessions = $this->authSessionRepository->findRecentForUser($user, 20);
+        $audits = $this->auditLogRepository->findRecentForUser($user, 20);
+        $request = $this->requestStack->getCurrentRequest();
+        $loginDate = $request?->server->getInt('REQUEST_TIME') > 0
+            ? (new \DateTimeImmutable())->setTimestamp($request->server->getInt('REQUEST_TIME'))
+            : new \DateTimeImmutable();
+        $loginHour = (int) $loginDate->format('G');
+
+        $ipAddresses = [];
+        $deviceFingerprints = [];
+        $locations = [];
+        $osNames = [];
+
+        foreach ($audits as $audit) {
+            $ipAddresses[] = trim($audit->getPrivateIpAddress());
+            $deviceFingerprints[] = trim((string) ($audit->getOsName() ?? '')) . '|' . trim((string) ($audit->getHostname() ?? ''));
+            $locations[] = trim((string) ($audit->getLocation() ?? ''));
+
+            $osName = trim((string) ($audit->getOsName() ?? ''));
+            if ($osName !== '') {
+                $osNames[] = $osName;
+            }
+        }
+
+        return [
+            'session_duration' => $this->estimateSessionDurationMinutes($sessions),
+            'is_revoked' => isset($sessions[0]) && $sessions[0]->isRevoked() ? 1 : 0,
+            'ip_change_count' => $this->countChanges($ipAddresses),
+            'device_change_count' => $this->countChanges($deviceFingerprints),
+            'location_change' => count(array_unique(array_filter($locations, static fn (string $value): bool => $value !== ''))) > 1 ? 1 : 0,
+            'login_hour' => $loginHour,
+            'is_night_login' => ($loginHour >= 22 || $loginHour < 6) ? 1 : 0,
+            'os_variation' => count(array_unique($osNames)),
+        ];
+    }
+
+    /**
+     * @param list<AuthSession> $sessions
+     */
+    private function estimateSessionDurationMinutes(array $sessions): int
+    {
+        if ($sessions === []) {
+            return 0;
+        }
+
+        $latest = $sessions[0];
+        $durationSeconds = max(0, $latest->getExpiresAt()->getTimestamp() - $latest->getCreatedAt()->getTimestamp());
+
+        return (int) floor($durationSeconds / 60);
+    }
+
+    /**
+     * @param list<string> $values
+     */
+    private function countChanges(array $values): int
+    {
+        $normalized = array_values(array_filter(
+            array_map(static fn (string $value): string => trim($value), $values),
+            static fn (string $value): bool => $value !== '',
+        ));
+
+        if (count($normalized) < 2) {
+            return 0;
+        }
+
+        $changes = 0;
+        $previous = $normalized[0];
+
+        foreach (array_slice($normalized, 1) as $value) {
+            if ($value !== $previous) {
+                ++$changes;
+            }
+
+            $previous = $value;
+        }
+
+        return $changes;
+    }
+
+    private function mapRiskLevel(int $prediction, float $confidence): ?string
+    {
+        return match ($prediction) {
+            2 => self::RISK_DANGER,
+            1 => self::RISK_MEDIUM,
+            0 => self::RISK_SAFE,
+            default => self::RISK_MEDIUM,
+        };
+    }
+
+    private function normalizeLevel(mixed $level): ?string
+    {
+        if ($level === null) {
+            return null;
+        }
+
+        $value = mb_strtoupper(trim((string) $level));
+
+        return match ($value) {
+            self::RISK_SAFE, self::RISK_MEDIUM, self::RISK_DANGER => $value,
+            default => self::RISK_MEDIUM,
+        };
+    }
+}

--- a/project/templates/access_control/pages/user_management.html.twig
+++ b/project/templates/access_control/pages/user_management.html.twig
@@ -33,6 +33,15 @@
                         <option value="DISABLED" {{ filters.accountStatus == 'DISABLED' ? 'selected' : '' }}>Disabled</option>
                     </select>
                 </label>
+                <label style="display: flex; flex-direction: column; gap: 0.5rem;">
+                    <span style="font-size: 0.875rem; font-weight: 500;">Risk level</span>
+                    <select class="ac-input" name="riskLevel" data-action="change->user-filters#onChange">
+                        <option value="">All risk levels</option>
+                        <option value="SAFE" {{ filters.riskLevel == 'SAFE' ? 'selected' : '' }}>SAFE</option>
+                        <option value="MEDIUM" {{ filters.riskLevel == 'MEDIUM' ? 'selected' : '' }}>MEDIUM</option>
+                        <option value="DANGER" {{ filters.riskLevel == 'DANGER' ? 'selected' : '' }}>DANGER</option>
+                    </select>
+                </label>
             </form>
             
             {% if users is empty %}
@@ -47,6 +56,7 @@
                                 <th>Role</th>
                                 <th>Status</th>
                                 <th>Presence</th>
+                                <th>Risk Level</th>
                                 <th style="text-align: right;">Actions</th>
                             </tr>
                         </thead>
@@ -65,6 +75,17 @@
                                     <span class="ac-badge ac-badge-{{ user.presenceStatus == 'ONLINE' ? 'success' : 'secondary' }}">
                                         {{ user.presenceStatus }}
                                     </span>
+                                </td>
+                                <td>
+                                    {% if user.riskLevel == 'SAFE' %}
+                                        <span class="ac-badge ac-badge-success">SAFE</span>
+                                    {% elseif user.riskLevel == 'DANGER' %}
+                                        <span class="ac-badge ac-badge-danger">DANGER</span>
+                                    {% elseif user.riskLevel == 'MEDIUM' %}
+                                        <span class="ac-badge ac-badge-warning">MEDIUM</span>
+                                    {% else %}
+                                        <span class="ac-badge ac-badge-secondary">N/A</span>
+                                    {% endif %}
                                 </td>
                                 <td style="text-align: right;">
                                     <button class="ac-icon-btn"
@@ -126,7 +147,7 @@
                 {% if pagination.totalPages > 1 %}
                 <div style="display: flex; justify-content: center; gap: 0.5rem; margin-top: 1.5rem;">
                     {% if pagination.page > 1 %}
-                        <a href="{{ path('ac_ui_users', {page: pagination.page - 1, email: filters.email, role: filters.role, accountStatus: filters.accountStatus}) }}" 
+                        <a href="{{ path('ac_ui_users', {page: pagination.page - 1, email: filters.email, role: filters.role, accountStatus: filters.accountStatus, riskLevel: filters.riskLevel}) }}" 
                            class="ac-ghost-btn">Previous</a>
                     {% endif %}
                     
@@ -135,7 +156,7 @@
                     </span>
                     
                     {% if pagination.page < pagination.totalPages %}
-                        <a href="{{ path('ac_ui_users', {page: pagination.page + 1, email: filters.email, role: filters.role, accountStatus: filters.accountStatus}) }}" 
+                        <a href="{{ path('ac_ui_users', {page: pagination.page + 1, email: filters.email, role: filters.role, accountStatus: filters.accountStatus, riskLevel: filters.riskLevel}) }}" 
                            class="ac-ghost-btn">Next</a>
                     {% endif %}
                 </div>

--- a/project/tests/Dto/Admin/UserFilterRequestTest.php
+++ b/project/tests/Dto/Admin/UserFilterRequestTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Dto\Admin;
+
+use App\Dto\Admin\UserFilterRequest;
+use PHPUnit\Framework\TestCase;
+
+final class UserFilterRequestTest extends TestCase
+{
+    public function testToFiltersIncludesRiskLevelWhenProvided(): void
+    {
+        $dto = new UserFilterRequest(
+            page: 1,
+            limit: 20,
+            email: 'john@example.com',
+            role: 'PATIENT',
+            accountStatus: 'ACTIVE',
+            riskLevel: 'DANGER',
+        );
+
+        self::assertSame([
+            'email' => 'john@example.com',
+            'role' => 'PATIENT',
+            'accountStatus' => 'ACTIVE',
+            'riskLevel' => 'DANGER',
+        ], $dto->toFilters());
+    }
+}
+

--- a/project/tests/Service/Risk/UserRiskServiceTest.php
+++ b/project/tests/Service/Risk/UserRiskServiceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service\Risk;
+
+use App\Entity\User;
+use App\Repository\AuditLogRepository;
+use App\Repository\AuthSessionRepository;
+use App\Service\Risk\UserRiskService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class UserRiskServiceTest extends TestCase
+{
+    public function testEvaluateAndStoreMapsDangerPrediction(): void
+    {
+        $user = $this->buildUser();
+        $service = $this->buildService([
+            'prediction' => 2,
+            'confidence' => 0.91,
+        ]);
+
+        $result = $service->evaluateAndStore($user, true);
+
+        self::assertSame('DANGER', $result['level']);
+        self::assertSame(2, $result['prediction']);
+        self::assertSame(0.91, $result['confidence']);
+        self::assertNull($result['error']);
+        self::assertSame('DANGER', $user->getRiskLevel());
+    }
+
+    public function testEvaluateAndStoreUsesHybridConfidenceRule(): void
+    {
+        $user = $this->buildUser();
+        $service = $this->buildService([
+            'prediction' => 0,
+            'confidence' => 0.72,
+        ]);
+
+        $result = $service->evaluateAndStore($user, true);
+
+        self::assertSame('MEDIUM', $result['level']);
+        self::assertSame(0, $result['prediction']);
+        self::assertSame(0.72, $result['confidence']);
+    }
+
+    public function testEvaluateAndStoreFallsBackToMediumOnApiFailure(): void
+    {
+        $user = $this->buildUser();
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->method('request')->willThrowException(new \RuntimeException('network_down'));
+
+        $service = $this->buildService(client: $client);
+        $result = $service->evaluateAndStore($user, true);
+
+        self::assertSame('MEDIUM', $result['level']);
+        self::assertSame('risk_api_unavailable', $result['error']);
+        self::assertSame('MEDIUM', $user->getRiskLevel());
+        self::assertNull($user->getRiskPrediction());
+    }
+
+    /**
+     * @param array{prediction?: int, confidence?: float}|null $apiPayload
+     */
+    private function buildService(?array $apiPayload = null, ?HttpClientInterface $client = null): UserRiskService
+    {
+        if (!$client instanceof HttpClientInterface) {
+            $response = $this->createMock(ResponseInterface::class);
+            $response->method('getStatusCode')->willReturn(200);
+            $response->method('toArray')->willReturn([
+                'prediction' => $apiPayload['prediction'] ?? 1,
+                'confidence' => $apiPayload['confidence'] ?? 0.87,
+            ]);
+
+            $client = $this->createMock(HttpClientInterface::class);
+            $client->method('request')->willReturn($response);
+        }
+
+        $auditRepo = $this->createMock(AuditLogRepository::class);
+        $auditRepo->method('findRecentForUser')->willReturn([]);
+
+        $sessionRepo = $this->createMock(AuthSessionRepository::class);
+        $sessionRepo->method('findRecentForUser')->willReturn([]);
+
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::create('/api/auth/login'));
+
+        return new UserRiskService(
+            $client,
+            new ArrayAdapter(),
+            $requestStack,
+            $sessionRepo,
+            $auditRepo,
+            new NullLogger(),
+            'https://user-risk-detection-api.vercel.app/api/v1/predict',
+            5.0,
+            1800,
+        );
+    }
+
+    private function buildUser(): User
+    {
+        return (new User())
+            ->setId('user-risk-test')
+            ->setEmail('risk@example.com')
+            ->setPassword('secret')
+            ->setRole('PATIENT')
+            ->setPresenceStatus('ONLINE')
+            ->setAccountStatus('ACTIVE')
+            ->setFaceRecognitionEnabled(false)
+            ->setCreatedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable());
+    }
+}
+


### PR DESCRIPTION
# Serinity Web | Access Control | User Risk Detection | #22

## Overview

- Integrate [user-risk-detection-api](https://github.com/zouari-oss/user-risk-detection-api) under `http://127.0.0.1:8000/admin/users`
- When user sign-in, we send his metrics:
```json
[
  "session_duration",
  "is_revoked",
  "ip_change_count",
  "device_change_count",
  "location_change",
  "login_hour",
  "is_night_login",
  "os_variation"
]
```
so we get `risk_level` and store it in `users.risk_level`

## Risk Level
| risk_level |
| ---------- |
| SAFE(0)    |
| MEDIUM(1)  |
| DANGER(2)  |

> See [user-risk-detection](https://github.com/zouari-oss/user-risk-detection) for more information